### PR TITLE
Only export the plugins module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,105 +1,103 @@
-(function(Chart) {
-  var cloneArray = function(srcAry) {
-    var dstAry = [];
-    var length = srcAry.length;
+var cloneArray = function (srcAry) {
+  var dstAry = [];
+  var length = srcAry.length;
 
-    for (var i = 0; i < length; i++) {
-      dstAry.push(srcAry[i]);
+  for (var i = 0; i < length; i++) {
+    dstAry.push(srcAry[i]);
+  }
+  return dstAry;
+};
+
+var setOriginalData = function (data) {
+  data.originalData = data.datasets.map(function (dataset) {
+    return cloneArray(dataset.data);
+  });
+};
+
+// set calculated rate (xx%) to data.calculatedData
+var calculateRate = function (data) {
+  var visibles = data.datasets.map(function (dataset) {
+    if (!dataset._meta) return true;
+
+    for (var i in dataset._meta) {
+      return !dataset._meta[i].hidden;
     }
-    return dstAry;
-  };
+  });
 
-  var setOriginalData = function(data) {
-    data.originalData = data.datasets.map(function(dataset) {
-      return cloneArray(dataset.data);
+  var totals = Array.apply(null, new Array(data.datasets[0].data.length)).map(function (el, i) {
+    return data.datasets.reduce(function (sum, dataset, j) {
+      var key = dataset.stack;
+      if (!sum[key]) sum[key] = 0;
+      sum[key] += dataset.data[i] * visibles[j];
+
+      return sum;
+    }, {});
+  });
+
+  data.calculatedData = data.datasets.map(function (dataset, i) {
+    return dataset.data.map(function (val, i) {
+      var total = totals[i][dataset.stack];
+      return val && total ? Math.round(val * 1000 / total) / 10 : 0;
     });
-  };
+  });
+};
 
-  // set calculated rate (xx%) to data.calculatedData
-  var calculateRate = function(data) {
-    var visibles = data.datasets.map(function(dataset) {
-      if (!dataset._meta) return true;
+var tooltipLabel = function (tooltipItem, data) {
+  var datasetIndex = tooltipItem.datasetIndex;
+  var index = tooltipItem.index;
+  var datasetLabel = data.datasets[datasetIndex].label || "";
+  var originalValue = data.originalData[datasetIndex][index];
+  var rateValue = data.calculatedData[datasetIndex][index];
 
-      for (var i in dataset._meta) {
-        return !dataset._meta[i].hidden;
-      }
-    });
+  return "" + datasetLabel + ": " + rateValue + "% (" + originalValue + ")";
+};
 
-    var totals = Array.apply(null, new Array(data.datasets[0].data.length)).map(function(el, i) {
-      return data.datasets.reduce(function(sum, dataset, j) {
-        var key = dataset.stack;
-        if (!sum[key]) sum[key] = 0;
-        sum[key] += dataset.data[i] * visibles[j];
+var reflectData = function (srcData, datasets) {
+  if (!srcData) return;
 
-        return sum;
-      }, {});
-    });
+  srcData.forEach(function (data, i) {
+    datasets[i].data = data;
+  });
+};
 
-    data.calculatedData = data.datasets.map(function(dataset, i) {
-      return dataset.data.map(function(val, i) {
-        var total = totals[i][dataset.stack];
-        return val && total ? Math.round(val * 1000 / total) / 10 : 0;
+var Stacked100Plugin = {
+  id: "stacked100",
+
+  beforeInit: function (chartInstance, pluginOptions) {
+    if (!pluginOptions.enable) return;
+
+    var xAxes = chartInstance.options.scales.xAxes;
+    var yAxes = chartInstance.options.scales.yAxes;
+    var isVertical = chartInstance.config.type === "bar" || chartInstance.config.type === "line";
+
+    [xAxes, yAxes].forEach(function (axes) {
+      axes.forEach(function (hash) {
+        hash.stacked = true;
       });
     });
-  };
-
-  var tooltipLabel = function(tooltipItem, data) {
-    var datasetIndex = tooltipItem.datasetIndex;
-    var index = tooltipItem.index;
-    var datasetLabel = data.datasets[datasetIndex].label || "";
-    var originalValue = data.originalData[datasetIndex][index];
-    var rateValue = data.calculatedData[datasetIndex][index];
-
-    return "" + datasetLabel + ": " + rateValue + "% (" + originalValue + ")";
-  };
-
-  var reflectData = function(srcData, datasets) {
-    if (!srcData) return;
-
-    srcData.forEach(function(data, i) {
-      datasets[i].data = data;
+    (isVertical ? yAxes : xAxes).forEach(function (hash) {
+      hash.ticks.min = 0;
+      hash.ticks.max = 100;
     });
-  };
 
-  var Stacked100Plugin = {
-    id: "stacked100",
+    // Replace tooltips
+    if (pluginOptions.hasOwnProperty("replaceTooltipLabel") && !pluginOptions.replaceTooltipLabel) return;
+    chartInstance.options.tooltips.callbacks.label = tooltipLabel;
+  },
 
-    beforeInit: function(chartInstance, pluginOptions) {
-      if (!pluginOptions.enable) return;
+  beforeDatasetsUpdate: function (chartInstance, pluginOptions) {
+    if (!pluginOptions.enable) return;
 
-      var xAxes = chartInstance.options.scales.xAxes;
-      var yAxes = chartInstance.options.scales.yAxes;
-      var isVertical = chartInstance.config.type === "bar" || chartInstance.config.type === "line";
+    setOriginalData(chartInstance.data);
+    calculateRate(chartInstance.data);
+    reflectData(chartInstance.data.calculatedData, chartInstance.data.datasets);
+  },
 
-      [xAxes, yAxes].forEach(function(axes) {
-        axes.forEach(function(hash) {
-          hash.stacked = true;
-        });
-      });
-      (isVertical ? yAxes : xAxes).forEach(function(hash) {
-        hash.ticks.min = 0;
-        hash.ticks.max = 100;
-      });
+  afterDatasetsUpdate: function (chartInstance, pluginOptions) {
+    if (!pluginOptions.enable) return;
 
-      // Replace tooltips
-      if (pluginOptions.hasOwnProperty("replaceTooltipLabel") && !pluginOptions.replaceTooltipLabel) return;
-      chartInstance.options.tooltips.callbacks.label = tooltipLabel;
-    },
+    reflectData(chartInstance.data.originalData, chartInstance.data.datasets);
+  }
+};
 
-    beforeDatasetsUpdate: function(chartInstance, pluginOptions) {
-      if (!pluginOptions.enable) return;
-
-      setOriginalData(chartInstance.data);
-      calculateRate(chartInstance.data);
-      reflectData(chartInstance.data.calculatedData, chartInstance.data.datasets);
-    },
-
-    afterDatasetsUpdate: function(chartInstance, pluginOptions) {
-      if (!pluginOptions.enable) return;
-
-      reflectData(chartInstance.data.originalData, chartInstance.data.datasets);
-    }
-  };
-
-  Chart.pluginService.register(Stacked100Plugin);
-}.call(this, Chart));
+export default Stacked100Plugin;


### PR DESCRIPTION
This changes make the plugin only exports itself for a better integration with modern workflows (webpack, etc.). Registering the plugins will be up to the user.

Usage will look like:

```javascript
import Stacked100 from 'chartjs-plugin-stacked100'

const chart = new Chart(ctx, {
        type: 'bar',
        plugins: [Stacked100],
        // ...
}
```