### PR TITLE
Handle availability of dataset data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,12 @@
         return !dataset._meta[i].hidden;
       }
     });
-
-    var totals = Array.apply(null, new Array(data.datasets[0].data.length)).map(function(el, i) {
+    
+    var datasetDataLength = 0;
+    if (data && data.datasets && data.datasets[0] && data.datasets[0].data) {
+      datasetDataLength = data.datasets[0].data.length;
+    }
+    var totals = Array.apply(null, new Array(datasetDataLength)).map(function(el, i) {
       return data.datasets.reduce(function(sum, dataset, j) {
         var key = dataset.stack;
         if (!sum[key]) sum[key] = 0;


### PR DESCRIPTION
# Merge Please 😄

## Short story
I am using `React.js` to draw my charts, and I am fetching my data from server and state of my charts by default is `null`, ant it is passing to chart, and throwing an error and drop full app, I want to show empty chart on `null`ed state, without your plugin it works well that means that it must work okay by using your plugin without any checks in my code

## Problem
If we pass `none` as data to `chart.js` constructor, your plugin throwing an exception on 28 line

![screen shot 2018-10-04 at 10 29 40 am](https://user-images.githubusercontent.com/13422799/46459077-85f6ea80-c7c0-11e8-8f57-2f67e1ffea32.png)
---

## Solution
I added few conditions for correct checking `data.dataset[0].data.length` so it is works correctly if we are passing `null` as a data parameter