### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,8 +81,8 @@
         });
       });
       (isVertical ? yAxes : xAxes).forEach(function(hash) {
-        hash.ticks.min = 0;
-        hash.ticks.max = 100;
+        if (!hash.ticks.min) hash.ticks.min = 0;
+        if (!hash.ticks.max) hash.ticks.max = 100;
       });
 
       // Replace tooltips


### PR DESCRIPTION
It may sound not that intuitive, but we would need to set ticks.min to another value than 0. 

The reason ist that we have datasets that are all close to 100%, but you want to better see the differences when one has 96.3% and the other 98.9%. If I can set ticks.min to in this example 95, I can better focus on the range that matters.

So I propose to use ticks.min and ticks.max if they are set, and set them to 0 rsp. 100 if not.

Would do you think?