### PR TITLE
Add option for percentage precision

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,6 @@
     });
   };
 
-    var precision = 2;
     var round = function(value) {
 		var multiplicator = Math.pow(10, precision);
 		return Math.round(value * 100 * multiplicator) / multiplicator;

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,6 @@
       return dataset.data.map(function(val, i) {
         var total = totals[i][dataset.stack];
         var dv = dataValue(val, isHorizontal);
-        return dv && total ? Math.round(dv * 1000 / total) / 10 : 0;
         return dv && total ? round(dv / total) : 0;
       });
     });

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@
     });
   };
 
+    var precision = 1;
     var round = function(value) {
 		var multiplicator = Math.pow(10, precision);
 		return Math.round(value * 100 * multiplicator) / multiplicator;

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,12 @@
     });
   };
 
+    var precision = 2;
+    var round = function(value) {
+		var multiplicator = Math.pow(10, precision);
+		return Math.round(value * 100 * multiplicator) / multiplicator;
+	};
+    
   var tooltipLabel = function(isHorizontal) {
     return function(tooltipItem, data) {
       var datasetIndex = tooltipItem.datasetIndex;
@@ -94,6 +100,14 @@
       var xAxes = chartInstance.options.scales.xAxes;
       var yAxes = chartInstance.options.scales.yAxes;
       var isVertical = chartInstance.config.type === "bar" || chartInstance.config.type === "line";
+      
+      if (pluginOptions.hasOwnProperty("precision")) {
+        if (!pluginOptions.precision) return;
+        var precisionOption = Math.floor(pluginOptions.precision);
+        if (isNaN(precisionOption)) return;
+        if (precisionOption < 0 || precisionOption > 16) return; 
+        precision = precisionOption;
+      };
 
       [xAxes, yAxes].forEach(function(axes) {
         axes.forEach(function(hash) {

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@
         var total = totals[i][dataset.stack];
         var dv = dataValue(val, isHorizontal);
         return dv && total ? Math.round(dv * 1000 / total) / 10 : 0;
+        return dv && total ? round(dv / total) : 0;
       });
     });
   };


### PR DESCRIPTION
I added a precision option that I needed to add flexibility to the percentage values. 
These precentage values can be rounded with x fraction digits. It is initialized to 1 which is the default now, but you can have e.g. 99,984% (precision of 3) if you wish. 
The option is added as option plugins.stacked100.precision.
What do you think?