### PR TITLE
[1.1.2][bug] Added support for data points as object

### DIFF
--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -49,5 +49,10 @@
     <div class="my-chart-container">
       <canvas id="my-chart-8" width="600" height="200"></canvas>
     </div>
+
+    <h3>Case.9 Objects as data points with undefined value</h1>
+    <div class="my-chart-container">
+      <canvas id="my-chart-9" width="600" height="200"></canvas>
+    </div>
   </body>
 </html>

--- a/examples/demo/index.ts
+++ b/examples/demo/index.ts
@@ -206,3 +206,46 @@ new Chart(getCanvas("my-chart-8"), {
     },
   },
 });
+
+new Chart(getCanvas("my-chart-9"), {
+  type: "bar",
+  data: {
+    labels: ["Foo", "Bar", "Baz", "Quuz"],
+    datasets: [
+      {
+        label: "bad",
+        data: [
+          { x: 0, y: -5 },
+          { x: 1, y: 25 },
+          { x: 2, y: undefined },
+          { x: 3, y: undefined },
+        ],
+        backgroundColor: "rgba(244, 143, 177, 0.6)",
+      },
+      {
+        label: "better",
+        data: [
+          { x: 0, y: 15 },
+          { x: 1, y: -10 },
+          { x: 2, y: 6 },
+          { x: 3, y: 4 },
+        ],
+        backgroundColor: "rgba(255, 235, 59, 0.6)",
+      },
+      {
+        label: "good",
+        data: [
+          { x: 0, y: 10 },
+          { x: 1, y: 8 },
+          { x: 2, y: 11 },
+          { x: 3, y: undefined },
+        ],
+        backgroundColor: "rgba(100, 181, 246, 0.6)",
+      },
+    ],
+  },
+  options: {
+    indexAxis: "x",
+    plugins,
+  },
+});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,7 +20,7 @@ const calculateRate = (
     return data.datasets.reduce((sum, dataset, j) => {
       const key = dataset.stack || defaultStackKey;
       if (!sum[key]) sum[key] = 0;
-      sum[key] += Math.abs(dataValue(dataset.data[i] || 0, isHorizontal)) * visibles[j];
+      sum[key] += Math.abs(dataValue(dataset.data[i], isHorizontal) || 0) * visibles[j];
 
       return sum;
     }, {});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -75,7 +75,7 @@ export const beforeInit: ExtendedPlugin["beforeInit"] = (chartInstance, args, pl
   const isHorizontal = isHorizontalChart(chartInstance);
   const targetAxis = isHorizontal ? "x" : "y";
   const hasNegative = chartInstance.data.datasets.some((dataset) => {
-    return dataset.data.some((value) => value < 0);
+    return dataset.data.some((value) => (dataValue(value, isHorizontal) || 0) < 0);
   });
   ["x", "y"].forEach((axis) => {
     const tickOption = axis === targetAxis ? getTickOption(hasNegative, fixNegativeScale) : {};


### PR DESCRIPTION
In fact, the problem is that I put `|| 0` in the wrong place. `Math.abs` returns `NaN` if input is an undefined value.

Added an example with objects

**before**:
<img width="635" alt="Screen Shot 2021-12-12 at 4 48 33 PM" src="https://user-images.githubusercontent.com/8962340/145717358-246c3c75-9ffd-42ec-b117-9f74b6ca46a2.png">
**after**:
<img width="627" alt="Screen Shot 2021-12-12 at 4 48 42 PM" src="https://user-images.githubusercontent.com/8962340/145717365-1c6ad8eb-aa90-465f-a094-941c98946040.png">

BTW: For some reason, negative values do not work, I will try to fix them too, if I have time.
Thank you