### PR TITLE
Improved that the stack property was required for composite graphs

### DIFF
--- a/examples/demo/index.ts
+++ b/examples/demo/index.ts
@@ -314,14 +314,12 @@ createChart("Case.12 Multiple axis(combo horizontal bar/line)", {
         label: "bad",
         data: [5, 25],
         backgroundColor: COLORS.red,
-        stack: "stack1",
         xAxisID: "axis1",
       },
       {
         label: "better",
         data: [15, 10],
         backgroundColor: COLORS.yellow,
-        stack: "stack1",
         xAxisID: "axis1",
       },
       {
@@ -337,6 +335,9 @@ createChart("Case.12 Multiple axis(combo horizontal bar/line)", {
     indexAxis: "y",
     plugins: { stacked100: { enable: true, axisId: "axis1" } },
     scales: {
+      y: {
+        stacked: true,
+      },
       axis1: {
         position: "top",
       },
@@ -356,14 +357,12 @@ createChart("Case.13 Multiple axis(combo vertical bar/line)", {
         label: "bad",
         data: [5, 25],
         backgroundColor: COLORS.red,
-        stack: "stack1",
         yAxisID: "axis1",
       },
       {
         label: "better",
         data: [15, 10],
         backgroundColor: COLORS.yellow,
-        stack: "stack1",
         yAxisID: "axis1",
       },
       {
@@ -371,6 +370,118 @@ createChart("Case.13 Multiple axis(combo vertical bar/line)", {
         label: "good",
         data: [43, 24],
         backgroundColor: COLORS.blue,
+        yAxisID: "axis2",
+      },
+    ],
+  },
+  options: {
+    plugins: { stacked100: { enable: true, axisId: "axis1" } },
+    scales: {
+      x: {
+        stacked: true,
+      },
+      axis1: {
+        position: "left",
+      },
+      axis2: {
+        position: "right",
+      },
+    },
+  },
+});
+
+createChart("Case.14 Multiple axis with stack(combo horizontal bar/line)", {
+  type: "bar",
+  data: {
+    labels: ["Foo", "Bar"],
+    datasets: [
+      {
+        label: "bad",
+        data: [5, 25],
+        backgroundColor: COLORS.red,
+        stack: "stack 0",
+        xAxisID: "axis1",
+      },
+      {
+        label: "better",
+        data: [15, 10],
+        backgroundColor: COLORS.yellow,
+        stack: "stack 0",
+        xAxisID: "axis1",
+      },
+      {
+        label: "good",
+        data: [10, 20],
+        backgroundColor: COLORS.blue,
+        stack: "stack 1",
+        xAxisID: "axis1",
+      },
+      {
+        label: "very good",
+        data: [5, 24],
+        backgroundColor: COLORS.green,
+        stack: "stack 1",
+        xAxisID: "axis1",
+      },
+      {
+        type: "line",
+        label: "L1",
+        data: [43, 24],
+        xAxisID: "axis2",
+      },
+    ],
+  },
+  options: {
+    indexAxis: "y",
+    plugins: { stacked100: { enable: true, axisId: "axis1" } },
+    scales: {
+      axis1: {
+        position: "top",
+      },
+      axis2: {
+        position: "bottom",
+      },
+    },
+  },
+});
+
+createChart("Case.15 Multiple stacked axis with stack(combo vertical bar/line)", {
+  type: "bar",
+  data: {
+    labels: ["Foo", "Bar"],
+    datasets: [
+      {
+        label: "bad",
+        data: [5, 25],
+        backgroundColor: COLORS.red,
+        stack: "stack 0",
+        yAxisID: "axis1",
+      },
+      {
+        label: "better",
+        data: [15, 10],
+        backgroundColor: COLORS.yellow,
+        stack: "stack 0",
+        yAxisID: "axis1",
+      },
+      {
+        label: "good",
+        data: [10, 20],
+        backgroundColor: COLORS.blue,
+        stack: "stack 1",
+        yAxisID: "axis1",
+      },
+      {
+        label: "very good",
+        data: [5, 24],
+        backgroundColor: COLORS.green,
+        stack: "stack 1",
+        yAxisID: "axis1",
+      },
+      {
+        type: "line",
+        label: "L1",
+        data: [43, 24],
         yAxisID: "axis2",
       },
     ],
@@ -388,7 +499,7 @@ createChart("Case.13 Multiple axis(combo vertical bar/line)", {
   },
 });
 
-createChart("Case.14 horizontal bar chart with parsing option", {
+createChart("Case.16 horizontal bar chart with parsing option", {
   type: "bar",
   data: {
     labels: ["Foo", "Bar"],
@@ -427,7 +538,7 @@ createChart("Case.14 horizontal bar chart with parsing option", {
   },
 });
 
-createChart("Case.15 Complex parsing options", {
+createChart("Case.17 Complex parsing options", {
   type: "bar",
   data: {
     labels: ["Alice", "Bob"],


### PR DESCRIPTION
As in the [sample](https://www.chartjs.org/docs/latest/samples/bar/stacked.html), Stacked bar graphs can be represented by using the `stacked` property as well as the `stack` property.
However, the current implementation does not work correctly for composite graphs without the stack property.
Therefore, the [sample code](https://www.chartjs.org/docs/latest/samples/other-charts/combo-bar-line.html) as in #92 will not work as expected.

The following images show the execution results of a case implemented using the `stacked` property instead of the `stack` property in [cases 12 and 13 of the example](https://github.com/y-takey/chartjs-plugin-stacked100/blob/2a7920a4cccbdde3b3ca15d0be16ff7e23bf9ef7/examples/demo/index.ts#L350-L389).

This PR solves the above problem by adding `targetAxisId` and `filter` to `summarizeValues` to make it more user-friendly.

```diff
- stack: "stack1",
+ y: {
+   stacked: true,
+ },
```
<img width="637" alt="SS 2024-10-30 18 41 51" src="https://github.com/user-attachments/assets/16e7ba4c-f897-4fd4-8a5c-85436d7c1ef8">